### PR TITLE
various fixes for build freetz workflow

### DIFF
--- a/.github/scripts/steps/build.sh
+++ b/.github/scripts/steps/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-make || make 
-rm -f images/latest.image
+make && rm -f images/latest.image

--- a/.github/scripts/steps/extra-config.sh
+++ b/.github/scripts/steps/extra-config.sh
@@ -7,6 +7,9 @@ ROOTEMU="$2"
 [[ "$TOOLS" == "yes" ]] && echo '# FREETZ_DOWNLOAD_TOOLCHAIN is not set' >> .config
 [[ "$TOOLS" != "yes" ]] && echo 'FREETZ_DOWNLOAD_TOOLCHAIN=y' >> .config
 
+[[ "$TOOLS" == "yes" ]] && echo '# FREETZ_HOSTTOOLS_DOWNLOAD is not set' >> .config
+[[ "$TOOLS" != "yes" ]] && echo 'FREETZ_HOSTTOOLS_DOWNLOAD=y' >> .config
+
 [[ "$ROOTEMU" == "pseudo" ]] && echo '# FREETZ_ROOTEMU_FAKEROOT is not set' >> .config
 [[ "$ROOTEMU" != "pseudo" ]] && echo 'FREETZ_ROOTEMU_FAKEROOT=y' >> .config
 

--- a/.github/workflows/test_freetz-ng_build_on_dockerimage.yml
+++ b/.github/workflows/test_freetz-ng_build_on_dockerimage.yml
@@ -42,8 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         docker: ${{ fromJson(needs.matrix.outputs.os) }}
-        runner: [ uhuntu-24.04, ubuntu-24.04-arm ]
-    runs-on: ${{ matrix.runner }} 
+        runner: [ ubuntu-24.04, ubuntu-24.04-arm ]
+    runs-on: '${{ matrix.runner }}'
     container:
       image: ghcr.io/pfichtner/pfichtner-freetz:${{ matrix.docker }}
       options: --user 1001:1001


### PR DESCRIPTION
This fixes the issue where the workflow is not retrieving the amd64 runners and always tries to download the tools-host by default, regardless of `input.tools`.