### PR TITLE
add more apt mirrors

### DIFF
--- a/provisioning/debian:11/04-apt-mirror.sh
+++ b/provisioning/debian:11/04-apt-mirror.sh
@@ -1,0 +1,23 @@
+add_apt_mirror() {
+mkdir -p /etc/apt/mirrors
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*debian\.org/debian-security#mirror+file:/etc/apt/mirrors/debian-security.list#g' \
+    -e 's#http://[^[:space:]]*debian\.org/debian#mirror+file:/etc/apt/mirrors/debian.list#g' \
+    $a; \
+done || exit 1
+}
+
+change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/debian-security.list <<EOF
+http://mirrors.dotsrc.org/debian-security
+http://deb.debian.org/debian-security
+EOF
+cat > /etc/apt/mirrors/debian.list <<EOF
+http://mirrors.dotsrc.org/debian
+http://deb.debian.org/debian
+EOF
+}
+
+change_mirror && add_apt_mirror

--- a/provisioning/debian:12/04-apt-mirror.sh
+++ b/provisioning/debian:12/04-apt-mirror.sh
@@ -1,0 +1,23 @@
+add_apt_mirror() {
+mkdir -p /etc/apt/mirrors
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*debian\.org/debian-security#mirror+file:/etc/apt/mirrors/debian-security.list#g' \
+    -e 's#http://[^[:space:]]*debian\.org/debian#mirror+file:/etc/apt/mirrors/debian.list#g' \
+    $a; \
+done || exit 1
+}
+
+change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/debian-security.list <<EOF
+http://mirrors.dotsrc.org/debian-security
+http://deb.debian.org/debian-security
+EOF
+cat > /etc/apt/mirrors/debian.list <<EOF
+http://mirrors.dotsrc.org/debian
+http://deb.debian.org/debian
+EOF
+}
+
+change_mirror && add_apt_mirror

--- a/provisioning/debian:13/04-apt-mirror.sh
+++ b/provisioning/debian:13/04-apt-mirror.sh
@@ -1,0 +1,23 @@
+add_apt_mirror() {
+mkdir -p /etc/apt/mirrors
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*debian\.org/debian-security#mirror+file:/etc/apt/mirrors/debian-security.list#g' \
+    -e 's#http://[^[:space:]]*debian\.org/debian#mirror+file:/etc/apt/mirrors/debian.list#g' \
+    $a; \
+done || exit 1
+}
+
+change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/debian-security.list <<EOF
+http://mirrors.dotsrc.org/debian-security
+http://deb.debian.org/debian-security
+EOF
+cat > /etc/apt/mirrors/debian.list <<EOF
+http://mirrors.dotsrc.org/debian
+http://deb.debian.org/debian
+EOF
+}
+
+change_mirror && add_apt_mirror

--- a/provisioning/ubuntu:20.04/04-apt-mirror.sh
+++ b/provisioning/ubuntu:20.04/04-apt-mirror.sh
@@ -1,0 +1,31 @@
+add_apt_mirror() {
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*ubuntu\.com/(ubuntu|ubuntu-ports)#mirror+file:///etc/apt/mirrors/ubuntu.list#g' \
+    $a; \
+done || exit 1
+}
+
+x86_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu
+http://archive.ubuntu.com/ubuntu
+EOF
+}
+
+arm_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu-ports
+http://ports.ubuntu.com/ubuntu-ports
+EOF
+}
+
+if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
+    x86_change_mirror && add_apt_mirror
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ]; then
+    arm_change_mirror && add_apt_mirror
+else
+    echo "Unsupported architecture: $(uname -m)"
+fi

--- a/provisioning/ubuntu:22.04/04-apt-mirror.sh
+++ b/provisioning/ubuntu:22.04/04-apt-mirror.sh
@@ -1,0 +1,31 @@
+add_apt_mirror() {
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*ubuntu\.com/(ubuntu|ubuntu-ports)#mirror+file:///etc/apt/mirrors/ubuntu.list#g' \
+    $a; \
+done || exit 1
+}
+
+x86_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu
+http://archive.ubuntu.com/ubuntu
+EOF
+}
+
+arm_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu-ports
+http://ports.ubuntu.com/ubuntu-ports
+EOF
+}
+
+if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
+    x86_change_mirror && add_apt_mirror
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ]; then
+    arm_change_mirror && add_apt_mirror
+else
+    echo "Unsupported architecture: $(uname -m)"
+fi

--- a/provisioning/ubuntu:24.04/04-apt-mirror.sh
+++ b/provisioning/ubuntu:24.04/04-apt-mirror.sh
@@ -1,0 +1,31 @@
+add_apt_mirror() {
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*ubuntu\.com/(ubuntu|ubuntu-ports)#mirror+file:///etc/apt/mirrors/ubuntu.list#g' \
+    $a; \
+done || exit 1
+}
+
+x86_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu
+http://archive.ubuntu.com/ubuntu
+EOF
+}
+
+arm_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu-ports
+http://ports.ubuntu.com/ubuntu-ports
+EOF
+}
+
+if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
+    x86_change_mirror && add_apt_mirror
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ]; then
+    arm_change_mirror && add_apt_mirror
+else
+    echo "Unsupported architecture: $(uname -m)"
+fi

--- a/provisioning/ubuntu:26.04/04-apt-mirror.sh
+++ b/provisioning/ubuntu:26.04/04-apt-mirror.sh
@@ -1,0 +1,31 @@
+add_apt_mirror() {
+for a in $(find /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources); do \
+    sed -E -i \
+    -e 's#http://[^[:space:]]*ubuntu\.com/(ubuntu|ubuntu-ports)#mirror+file:///etc/apt/mirrors/ubuntu.list#g' \
+    $a; \
+done || exit 1
+}
+
+x86_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu
+http://archive.ubuntu.com/ubuntu
+EOF
+}
+
+arm_change_mirror() {
+mkdir -p /etc/apt/mirrors
+cat > /etc/apt/mirrors/ubuntu.list <<EOF
+http://mirrors.dotsrc.org/ubuntu-ports
+http://ports.ubuntu.com/ubuntu-ports
+EOF
+}
+
+if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
+    x86_change_mirror && add_apt_mirror
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ]; then
+    arm_change_mirror && add_apt_mirror
+else
+    echo "Unsupported architecture: $(uname -m)"
+fi


### PR DESCRIPTION
This adds multiple apt mirrors so that when building docker images in parallel, the standard mirrors of Debian and Ubuntu are not overloaded.