### PR TITLE
support for build arm64 container over a workflow to publish to docker.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,17 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6
 
+      - name: Setup QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v4
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -48,11 +59,18 @@ jobs:
         run: bats tests/test.sh
 
       - name: Push Docker image to Docker Hub
+        id: push
         if: success()  # Ensure this step runs only if the tests pass
         uses: docker/build-push-action@v7
-        with:
+        with: &build_args
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: ${{ env.BUILD_ARGS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Retry Push Docker image to Docker Hub
+        if: ${{ steps.push.outcome == 'failure' }}
+        uses: docker/build-push-action@v7
+        with: *build_args


### PR DESCRIPTION
This adapts the workflow for Docker Hub so that it can also build and publish arm64 containers.