### PR TITLE
ci: reduce parameters if it is always defaulf without it

### DIFF
--- a/.github/workflows/build-all-and-push-to-ghcr.yml
+++ b/.github/workflows/build-all-and-push-to-ghcr.yml
@@ -61,14 +61,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Setup QEMU
-        id: qemu
         uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
 
       - name: Setup Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,14 +17,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup QEMU
-        id: qemu
         uses: docker/setup-qemu-action@v4
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
 
       - name: Setup Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
This reduces the number of parameters used in ua qemu because, according to its documentation, these are already used by default.