### PR TITLE
add fedora 44 to build freetz test

### DIFF
--- a/.github/scripts/steps/prepare-matrix.sh
+++ b/.github/scripts/steps/prepare-matrix.sh
@@ -8,6 +8,7 @@ if [[ "$INPUT_OS" != "_all" ]]; then
 else
   OSLIST="
 fedora-43-latest
+fedora-44-latest
 debian-13-latest
 ubuntu-22.04-latest
 ubuntu-24.04-latest


### PR DESCRIPTION
This adds the missing entry to use fedora 44 for the build and test freetz workflow