### PR TITLE
ci: replace `actions-comment-pull-request` action to gh cli

### DIFF
--- a/.github/workflows/fetch-and-update-freetz-ng-prerequisites.yml
+++ b/.github/workflows/fetch-and-update-freetz-ng-prerequisites.yml
@@ -70,8 +70,4 @@ jobs:
 
     - name: Comment PR
       if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
-      uses: thollander/actions-comment-pull-request@v3
-      with:
-        github-token: ${{ env.GH_TOKEN }}
-        pr-number: ${{ steps.create_pr.outputs.pull-request-number }}
-        file-path: .dependency-diff.txt
+      run: gh pr comment "${{ steps.create_pr.outputs.pull-request-number }}" --body-file .dependency-diff.txt


### PR DESCRIPTION
This changes the no longer maintained `thollander/actions-comment-pull-request` action to a gh cli variant