### PR TITLE
Fix Podman UID-mapping issue when using USE_UID_FROM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,13 @@ fi
 [ `id -u` -eq 0 ] || setToDefaults
 
 [ -z "$BUILD_USER" ] && BUILD_USER="$DEFAULT_BUILD_USER"
-[ -n "$USE_UID_FROM" ] && BUILD_USER_UID=`stat -c "%u" $USE_UID_FROM`
+if [ -n "$USE_UID_FROM" ]; then
+    BUILD_USER_UID=$(stat -c "%u" "$USE_UID_FROM")
+
+    # Podman user namespace mappings can make a bind mount appear
+    # owned by root inside the container. Do not mirror UID 0.
+    [ "$BUILD_USER_UID" -eq 0 ] && unset BUILD_USER_UID
+fi
 
 if [ `id -u` -eq 0 ]; then
 	# better read HOME/DHOME from /etc/default/useradd /etc/adduser.conf

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -149,3 +149,11 @@ teardown() {
   [ "$output" == $'1000' ]
 }
 
+@test "USE_UID_FROM owned by root falls back to non-root uid" {
+  uid=$(podman run --rm -i \
+      -v /:/workspace:ro \
+      -e USE_UID_FROM=/workspace \
+      docker.io/$IMAGE \
+      id -u)
+  [ "$uid" -ne 0 ]
+}


### PR DESCRIPTION
## Fix: Ignore UID 0 from `USE_UID_FROM` under Podman user namespaces

### Problem

When `USE_UID_FROM` is set, the entrypoint derives `BUILD_USER_UID` from the ownership of the specified path:

```bash
BUILD_USER_UID=$(stat -c "%u" "$USE_UID_FROM")