### PR TITLE
fix(dependabot): Unintended switch of `docker/login-action` from a major version to a fixed-tag version.

### DIFF
--- a/.github/workflows/build-all-and-push-to-ghcr.yml
+++ b/.github/workflows/build-all-and-push-to-ghcr.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
This fixes an unintended switch of `docker/login-action` from a major version to a fixed-tag version, as described in https://github.com/dependabot/dependabot-core/issues/15738.

Another unwanted switch from a major version to a fixed-tag version should not occur again as it was fixed last week in dependabot-code [v0.391.0](https://github.com/dependabot/dependabot-core/releases/tag/v0.391.0).

Already discussed in Freetz-NG: https://github.com/Freetz-NG/freetz-ng/pull/1560