### PR TITLE
refactor: improve logic for deleting untagged images

### DIFF
--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -26,16 +26,28 @@ jobs:
             /users/$OWNER/packages/container/$PACKAGE/versions \
             --paginate)
 
-          echo "$versions" | jq -c '.[]' | while read version; do
-            tags=$(echo "$version" | jq '.metadata.container.tags')
+          tagged_digests=$(echo "$versions" \
+            | jq -r '.[] | select(.metadata.container.tags != null and (.metadata.container.tags | length) > 0) | .metadata.container.digest // empty' \
+            | sort -u)
+
+          echo "$versions" | jq -c '.[]' | while read -r version; do
+            tags=$(echo "$version" | jq -c '.metadata.container.tags // []')
+            digest=$(echo "$version" | jq -r '.metadata.container.digest // empty')
             updated=$(echo "$version" | jq -r '.updated_at')
             updated_ts=$(date -d "$updated" +%s)
             id=$(echo "$version" | jq -r '.id')
 
-            if [ "$tags" = "[]" ] && [ "$updated_ts" -lt "$CUTOFF" ]; then
-              echo "Deleting untagged version $id"
-              gh api \
-                --method DELETE \
-                /users/$OWNER/packages/container/$PACKAGE/versions/$id
+            if [ "$tags" = "[]" ]; then
+              if [ -n "$digest" ] && printf '%s\n' "$tagged_digests" | grep -Fxq "$digest"; then
+                echo "Skipping untagged version $id because its digest $digest is still referenced by a tagged image"
+                continue
+              fi
+
+              if [ "$updated_ts" -lt "$CUTOFF" ]; then
+                echo "Deleting untagged version $id"
+                gh api \
+                  --method DELETE \
+                  /users/$OWNER/packages/container/$PACKAGE/versions/$id
+              fi
             fi
           done


### PR DESCRIPTION
This improves the logic for deleting untagged images by ensuring that only untagged packages that are not referenced from a tagged image are deleted.

Without this logic improvement, the result is that pulling `ghcr.io/pfichtner/pfichtner-freetz:debian-13-latest` no longer works since https://github.com/pfichtner/pfichtner-freetz/actions/runs/31859911043/job/94951322454:

```
docker: Error response from daemon: failed to resolve reference "ghcr.io/pfichtner/pfichtner-freetz@sha256:211887356cfd38d96b5067c84b42dfaf4501987fe5c6ab4f6b4599107b1a82cd": ghcr.io/pfichtner/pfichtner-freetz@sha256:211887356cfd38d96b5067c84b42dfaf4501987fe5c6ab4f6b4599107b1a82cd: not found
```
