### PR TITLE
fix: update locale generation to ensure en_US.UTF-8 is properly set

### DIFF
--- a/provisioning/debian:11/60-set-locale.sh
+++ b/provisioning/debian:11/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/debian:11/60-set-locale.sh
+++ b/provisioning/debian:11/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
-locale-gen en_US.UTF-8
-
+sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/debian:12/60-set-locale.sh
+++ b/provisioning/debian:12/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/debian:12/60-set-locale.sh
+++ b/provisioning/debian:12/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
-locale-gen en_US.UTF-8
-
+sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/debian:13/60-set-locale.sh
+++ b/provisioning/debian:13/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/debian:13/60-set-locale.sh
+++ b/provisioning/debian:13/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
-locale-gen en_US.UTF-8
-
+sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/ubuntu:20.04/60-set-locale.sh
+++ b/provisioning/ubuntu:20.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/ubuntu:20.04/60-set-locale.sh
+++ b/provisioning/ubuntu:20.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/ubuntu:22.04/60-set-locale.sh
+++ b/provisioning/ubuntu:22.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/ubuntu:22.04/60-set-locale.sh
+++ b/provisioning/ubuntu:22.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/ubuntu:24.04/60-set-locale.sh
+++ b/provisioning/ubuntu:24.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/ubuntu:24.04/60-set-locale.sh
+++ b/provisioning/ubuntu:24.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)

--- a/provisioning/ubuntu:26.04/60-set-locale.sh
+++ b/provisioning/ubuntu:26.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)

--- a/provisioning/ubuntu:26.04/60-set-locale.sh
+++ b/provisioning/ubuntu:26.04/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
 locale-gen en_US.UTF-8
-locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" && exit 1)
+locale -a | grep -Ei '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)


### PR DESCRIPTION
This fixes the problem that setting locales no longer works under all Debian versions with `locale-gen en_US.UTF-8` and the uclibc build fails: https://github.com/Freetz-NG/freetz-ng/pull/1572#issuecomment-5307659019

Additionally, a check is added which verifies whether the locales were actually generated and terminates the docker build with an error if the locales were not generated correctly.