### PR TITLE
ci: add debian14 to test freetz-ng build

### DIFF
--- a/.github/scripts/steps/prepare-matrix.sh
+++ b/.github/scripts/steps/prepare-matrix.sh
@@ -10,6 +10,7 @@ else
 fedora-43-latest
 fedora-44-latest
 debian-13-latest
+debian-14-latest
 ubuntu-22.04-latest
 ubuntu-24.04-latest
 ubuntu-26.04-latest


### PR DESCRIPTION
This adds Debian 14 to the test freetz-ng build workflow.