### PR TITLE
fix: update locale generation to ensure en_US.UTF-8 is properly set (again)

### DIFF
--- a/provisioning/debian:forky/60-set-locale.sh
+++ b/provisioning/debian:forky/60-set-locale.sh
@@ -1,3 +1,3 @@
 command -v locale-gen >/dev/null 2>&1 || apt-get -y install locales
-locale-gen en_US.UTF-8
-
+sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+locale -a | grep -qEi '^(en_US)' || (echo "failed to generate locales" >&2 && exit 1)


### PR DESCRIPTION
This fixes the same problem again as in #116, which was reversed in Debian 14 by https://github.com/pfichtner/pfichtner-freetz/commit/f873a116e987ee57e48aafe1b7f3e44415fcb25c, thus causing the gclib [error](https://github.com/Freetz-NG/freetz-ng/pull/1572#issuecomment-5307659019) to reappear.