### PR TITLE
fix: bats test for podman

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -139,7 +139,7 @@ teardown() {
 # ---------------------------------------------------------------------------------------------------------
 
 @test "podman keep-id produces valid uid mapping" {
-  uid=$(podman run --rm --userns keep-id -i $PODMAN_IMAGE id -u)
+  uid=$(podman run --rm --userns keep-id -e BUILD_USER_UID=$(id -u) -i $PODMAN_IMAGE id -u)
 
   [[ "$uid" =~ ^[0-9]+$ ]]
 


### PR DESCRIPTION
This fixes the current bug that appeared in the bats test workflow: https://github.com/pfichtner/pfichtner-freetz/actions/runs/32520572641/job/96891655551#step:10:58
Due to the error, version [0.4.5](https://github.com/pfichtner/pfichtner-freetz/releases/tag/0.4.5) has still not been published on [docker hub](https://hub.docker.com/r/pfichtner/freetz/tags).